### PR TITLE
Nikto escape target url

### DIFF
--- a/src/nikto_command_builder.rb
+++ b/src/nikto_command_builder.rb
@@ -10,7 +10,7 @@ class NiktoCommandBuilder
 			'perl /sectools/nikto-master/program/nikto.pl',
 			'-F csv',
 			"-o #{@filename}",
-			"-h #{@config.nikto_target}",
+			"-h \"#{@config.nikto_target}\"",
 		]
 
 		if ENV.has_key? 'DEBUG'

--- a/tests/nikto_command_builder_test.rb
+++ b/tests/nikto_command_builder_test.rb
@@ -27,7 +27,7 @@ class NiktoCommandBuilderTest < Test::Unit::TestCase
 
     assert_equal(
         cmd.build,
-        'perl /sectools/nikto-master/program/nikto.pl -F csv -o /tmp/report-49bf7fd3-8512-4d73-a28f-608e493cd726.csv -h localhost'
+        'perl /sectools/nikto-master/program/nikto.pl -F csv -o /tmp/report-49bf7fd3-8512-4d73-a28f-608e493cd726.csv -h "localhost"'
     )
   end
 
@@ -37,7 +37,7 @@ class NiktoCommandBuilderTest < Test::Unit::TestCase
 
     assert_equal(
         cmd.build,
-        'perl /sectools/nikto-master/program/nikto.pl -F csv -o /tmp/report-49bf7fd3-8512-4d73-a28f-608e493cd726.csv -h localhost -p 8080'
+        'perl /sectools/nikto-master/program/nikto.pl -F csv -o /tmp/report-49bf7fd3-8512-4d73-a28f-608e493cd726.csv -h "localhost" -p 8080'
     )
   end
 
@@ -47,7 +47,7 @@ class NiktoCommandBuilderTest < Test::Unit::TestCase
 
     assert_equal(
         cmd.build,
-        'perl /sectools/nikto-master/program/nikto.pl -F csv -o /tmp/report-49bf7fd3-8512-4d73-a28f-608e493cd726.csv -h localhost -nossl'
+        'perl /sectools/nikto-master/program/nikto.pl -F csv -o /tmp/report-49bf7fd3-8512-4d73-a28f-608e493cd726.csv -h "localhost" -nossl'
     )
   end
 end


### PR DESCRIPTION
Escape the interpolated target url to avoid errors with urls, that contain subdirectories.